### PR TITLE
Fix scan modal

### DIFF
--- a/components/qr scanner/CameraScanner.tsx
+++ b/components/qr scanner/CameraScanner.tsx
@@ -35,23 +35,6 @@ function CameraScannerView({
   const [imageLibraryPermission, requestImageLibraryPermission] = ImagePicker.useMediaLibraryPermissions();
   const [isProcessingImage, setIsProcessingImage] = useState(false);
 
-  // Use a ref to avoid stale closure in PanResponder
-  const onCloseRef = useRef(onClose);
-  onCloseRef.current = onClose;
-
-  const panResponder = useMemo(
-    () => PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
-      onMoveShouldSetPanResponder: () => true,
-      onPanResponderRelease: (_, gestureState) => {
-        if (gestureState.dy > 80 && Math.abs(gestureState.dx) < 50) {
-          onCloseRef.current();
-        }
-      },
-    }),
-    []
-  );
-
   const handleChooseImage = useCallback(async () => {
     Haptics.selectionAsync();
     try {
@@ -131,7 +114,7 @@ function CameraScannerView({
           onPress={onClose}
         />
         {/* Modal overlay with camera inside */}
-        <View style={styles.modalContainer} {...panResponder.panHandlers}>
+        <View style={styles.modalContainer}>
           <CameraView
             onBarcodeScanned={isScanned ? undefined : stableBarcodeHandler}
             barcodeScannerSettings={barcodeScannerSettings}


### PR DESCRIPTION
The pan responder blocks input to all elements beneath it on android - so we have to remove this. I don't think swipe here matters much given there is already 2 ways to close the modal.